### PR TITLE
Add `locations` field to introspection query

### DIFF
--- a/Sources/GraphQLRouteCollection/GraphQLRouteCollection+Introspection.swift
+++ b/Sources/GraphQLRouteCollection/GraphQLRouteCollection+Introspection.swift
@@ -13,6 +13,7 @@ extension GraphQLRouteCollection {
             directives {
                 name
                 description
+                locations
                 args {
                     ...InputValue
                 }


### PR DESCRIPTION
The latest version of the iOS Apollo code generation expects a `locations` field in the introspection query, or it will fail.
